### PR TITLE
chore: Update `jsonschema` to `0.16.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ pg_test = []
 pgx = "0.4.0"
 pgx-macros = "0.4.0"
 serde_json = "1.0.79"
-jsonschema = "0.15.0"
+jsonschema = "0.16.0"
 jtd = "0.3.1"
 avro-rs = "0.13.0"
 


### PR DESCRIPTION
Hi! I am the author of the jsonschema crate you're using.

It seems you were not affected by the recent compilation issues in the 0.15.x series, but I thought that I'll submit a PR that bumps jsonschema to its latest version anyway :) Hope it is ok