### PR TITLE
Disable file and http default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ pg_test = []
 pgx = "0.4.0"
 pgx-macros = "0.4.0"
 serde_json = "1.0.79"
-jsonschema = "0.16.0"
+jsonschema = {version = "0.16.0", default-features = false, features = []}
 jtd = "0.3.1"
 avro-rs = "0.13.0"
 


### PR DESCRIPTION
shameless copy of https://github.com/supabase/pg_jsonschema/pull/12
feels a bit more secure to not have the database use the wild wild web

note to self: what about jtd and avro 